### PR TITLE
Prelude tune-up part 2

### DIFF
--- a/Example/Prelude.playground/Contents.swift
+++ b/Example/Prelude.playground/Contents.swift
@@ -94,7 +94,7 @@ let people = [
     Person(firstName: "foo", lastName: "bar"),
     Person(firstName: "baz", lastName: "qux")
 ]
-let reduceFirstNames = bigReducer.contramap { (person: Person) in person.firstName }
+let reduceFirstNames = bigReducer.pullback { (person: Person) in person.firstName }
 people.reduce(into: [], reduceFirstNames)
 
 //

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 `Prelude` is a library, developed at [Wayfair](https://www.wayfair.com), for functional programming in Swift. We use this library in [our apps](https://itunes.apple.com/us/developer/wayfair-llc/id525522335) to build features in a functional style.
 
+## Installation
+
+`Prelude` can be installed in your project via [Carthage](https://github.com/Carthage/Carthage) or [Swift Package Manager](https://swift.org/package-manager/). [CocoaPods](https://cocoapods.org) support is [forthcoming](https://github.com/wayfair/prelude/issues/5).
+
+### Carthage customization hook
+
+If you’re incorporating `Prelude` via Carthage and need to tweak build settings (for example, perhaps you want to build the library as a static framework instead, to [improve app launch times](https://developer.apple.com/videos/play/wwdc2016/406/)), we’ve included a reference to a [magic customization file](https://github.com/wayfair/prelude/blob/master/xcconfigs/Prelude.xcconfig#L19) which may be able to help you.
+
+If there’s anything else we can do to support integrating Prelude into your project, please open an issue!
+
 ## Contents
 
 * *Change Tracking*: a specialization of the Writer monad that keeps track of changes to an enclosed value

--- a/xcconfigs/Prelude.xcconfig
+++ b/xcconfigs/Prelude.xcconfig
@@ -15,3 +15,5 @@ MACOSX_DEPLOYMENT_TARGET = 10.13
 INFOPLIST_FILE = Supporting Files/Info.plist
 
 APPLICATION_EXTENSION_API_ONLY = YES
+
+#include? "../../../../Prelude-Optional-Custom.xcconfig"

--- a/xcconfigs/Prelude.xcconfig
+++ b/xcconfigs/Prelude.xcconfig
@@ -16,4 +16,13 @@ INFOPLIST_FILE = Supporting Files/Info.plist
 
 APPLICATION_EXTENSION_API_ONLY = YES
 
-#include? "../../../../Prelude-Optional-Custom.xcconfig"
+// With Carthage, four sets of `..`s corresponds to the top-level directory of the app
+// which has taken this dependency (in other words, the project that is using Prelude).
+// Create a `Prelude-Overrides.xcconfig` in this location to optionally override build
+// settings set in this xcconfig.
+//
+// For example, to use Prelude in your project as a static framework, create
+// a `MyApp/Prelude-Overrides.xcconfig` that contains `MACH_O_TYPE = staticlib`.
+//
+// If you have no customizations, you can completely ignore this.
+#include? "../../../../Prelude-Overrides.xcconfig"


### PR DESCRIPTION
* fix one stray reference to `contramap` in the playground (whoops)
* add an `#include?` to `Prelude.xcconfig` for custom optional build settings
* update docs with brief explanation of the above