### PR TITLE
Refinement types

### DIFF
--- a/Example/Prelude.playground/Pages/change-tracking.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/change-tracking.xcplaygroundpage/Contents.swift
@@ -1,3 +1,12 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
 import Prelude
 
 //
@@ -72,57 +81,3 @@ let anotherPerson = pure(curry(Person.init))
     <*> Changeable(hasChanged: false, value: "foo")
     <*> Changeable(hasChanged: false, value: "bar")
 anotherPerson.hasChanged // => false
-
-//
-// Reducers
-//
-
-// reducers have an `inout` “state” by default
-let reducer: Reducer<[String], String> = .init { arr, item in arr.append(item) }
-
-// but can also be written with an immutable state
-let reduceCaps: Reducer<[String], String> = .nextPartialResult { arr, item in
-    return arr + [item.uppercased()]
-}
-
-// combine reducers with `<>` to execute them in sequence
-let bigReducer = reducer <> reduceCaps
-["foo", "bar", "baz"].reduce([], bigReducer)
-
-// use `contramap` to make it so existing reducers can chomp other types of values
-let people = [
-    Person(firstName: "foo", lastName: "bar"),
-    Person(firstName: "baz", lastName: "qux")
-]
-let reduceFirstNames = bigReducer.pullback { (person: Person) in person.firstName }
-people.reduce(into: [], reduceFirstNames)
-
-//
-// Use both together!
-//
-
-/// update a `Person` by taking the first component of a tuple as the new first name
-let processFirstName: Reducer<Changeable<Person>, (String, String)> = .init { person, tuple in
-    let (newValue, _) = tuple
-    person.write(newValue, at: \.firstName)
-}
-
-/// update a `Person` by taking the second component of a tuple as the new last name
-let processLastName: Reducer<Changeable<Person>, (String, String)> = .init { person, tuple in
-    let (_, newValue) = tuple
-    person.write(newValue, at: \.lastName)
-}
-
-let redundantChanges = [("foo", "bar"), ("foo", "bar")]
-redundantChanges.reduce(
-    into: pure(Person(firstName: "foo", lastName: "bar")),
-    processFirstName <> processLastName
-    )
-    .hasChanged // => false
-
-let nonRedundantChanges = [("foo", "bar"), ("foo", "qux")]
-nonRedundantChanges.reduce(
-    into: pure(Person(firstName: "foo", lastName: "bar")),
-    processFirstName <> processLastName
-    )
-    .hasChanged // => true

--- a/Example/Prelude.playground/Pages/reducers.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/reducers.xcplaygroundpage/Contents.swift
@@ -1,0 +1,66 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
+import Prelude
+
+//
+// Reducers
+//
+
+struct Person { var firstName, lastName: String }
+
+// reducers have an `inout` “state” by default
+let reducer: Reducer<[String], String> = .init { arr, item in arr.append(item) }
+
+// but can also be written with an immutable state
+let reduceCaps: Reducer<[String], String> = .nextPartialResult { arr, item in
+    return arr + [item.uppercased()]
+}
+
+// combine reducers with `<>` to execute them in sequence
+let bigReducer = reducer <> reduceCaps
+["foo", "bar", "baz"].reduce([], bigReducer)
+
+// use `contramap` to make it so existing reducers can chomp other types of values
+let people = [
+    Person(firstName: "foo", lastName: "bar"),
+    Person(firstName: "baz", lastName: "qux")
+]
+let reduceFirstNames = bigReducer.pullback { (person: Person) in person.firstName }
+people.reduce(into: [], reduceFirstNames)
+
+//
+// Use both together!
+//
+
+/// update a `Person` by taking the first component of a tuple as the new first name
+let processFirstName: Reducer<Changeable<Person>, (String, String)> = .init { person, tuple in
+    let (newValue, _) = tuple
+    person.write(newValue, at: \.firstName)
+}
+
+/// update a `Person` by taking the second component of a tuple as the new last name
+let processLastName: Reducer<Changeable<Person>, (String, String)> = .init { person, tuple in
+    let (_, newValue) = tuple
+    person.write(newValue, at: \.lastName)
+}
+
+let redundantChanges = [("foo", "bar"), ("foo", "bar")]
+redundantChanges.reduce(
+    into: pure(Person(firstName: "foo", lastName: "bar")),
+    processFirstName <> processLastName
+    )
+    .hasChanged // => false
+
+let nonRedundantChanges = [("foo", "bar"), ("foo", "qux")]
+nonRedundantChanges.reduce(
+    into: pure(Person(firstName: "foo", lastName: "bar")),
+    processFirstName <> processLastName
+    )
+    .hasChanged // => true

--- a/Example/Prelude.playground/Pages/reducers.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/reducers.xcplaygroundpage/Contents.swift
@@ -13,8 +13,6 @@ import Prelude
 // Reducers
 //
 
-struct Person { var firstName, lastName: String }
-
 // reducers have an `inout` “state” by default
 let reducer: Reducer<[String], String> = .init { arr, item in arr.append(item) }
 
@@ -27,7 +25,9 @@ let reduceCaps: Reducer<[String], String> = .nextPartialResult { arr, item in
 let bigReducer = reducer <> reduceCaps
 ["foo", "bar", "baz"].reduce([], bigReducer)
 
-// use `contramap` to make it so existing reducers can chomp other types of values
+struct Person { var firstName, lastName: String }
+
+// use `pullback` to make it so existing reducers can chomp other types of values
 let people = [
     Person(firstName: "foo", lastName: "bar"),
     Person(firstName: "baz", lastName: "qux")
@@ -36,7 +36,7 @@ let reduceFirstNames = bigReducer.pullback { (person: Person) in person.firstNam
 people.reduce(into: [], reduceFirstNames)
 
 //
-// Use both together!
+// Use reducers and `Changeable` together!
 //
 
 /// update a `Person` by taking the first component of a tuple as the new first name

--- a/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
@@ -75,21 +75,21 @@ func doImportantBusinessLogic3(with person: Refined<Person, ValidName2>) {
 }
 
 // here are some of the basic refinements that are already in the library
-Int.GreaterThanZero.of(1)
+Int.GreaterThanZero.of(1) // => ok
 
-Int.GreaterThan<One>.of(-99)
+Int.GreaterThan<One>.of(-99) // => nil
 
-String.NonEmpty.of("foo")
+String.NonEmpty.of("foo") // => ok
 
-String.NonEmpty.of("")
+String.NonEmpty.of("") // => nil
 
 // conditional conformance of refined types works as expected
-Int.GreaterThanZero.of(1) == Int.GreaterThanZero.of(1)
+Int.GreaterThanZero.of(1) == Int.GreaterThanZero.of(1) // => true
 
 // to `compactMap` **and** refine at the same time, use `refineMap`
-let bar = [-1, 0, 1, 2, 3].refineMap(Int.GreaterThanZero.self)
+let bar = [-1, 0, 1, 2, 3].refineMap(Int.GreaterThanZero.self) // => (3 values)
 
 // you can also write it like this
 let foo: [Refined<Int, Int.GreaterThanZero>] = [-1, 0, 1, 2, 3].refineMap()
 
-foo == bar
+foo == bar // => true

--- a/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
@@ -1,0 +1,56 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
+import Prelude
+
+//
+// Refinement types
+//
+
+enum GreaterThanZero: Refinement {
+    typealias RefinedType = Double
+    static func isValid(_ value: Double) -> Bool {
+        return value > 0.0
+    }
+}
+
+GreaterThanZero.of(1)
+
+GreaterThanZero.of(-99)
+
+enum NotTwentyTwo: Refinement {
+    typealias RefinedType = Double
+    static func isValid(_ value: Double) -> Bool {
+        return value != 22.0
+    }
+}
+
+Both<GreaterThanZero, NotTwentyTwo>.of(22)
+
+Both<GreaterThanZero, NotTwentyTwo>.of(-99)
+
+Both<GreaterThanZero, NotTwentyTwo>.of(100)
+
+typealias MyRefinedDouble = Refined<Double, Both<GreaterThanZero, NotTwentyTwo>>
+
+try MyRefinedDouble.init(9)
+
+//try MyRefinedDouble.init(22) // will `throw`
+
+let myDouble = MyRefinedDouble.init(9)
+
+left(myDouble)
+
+let anotherDouble = OneOf<GreaterThanZero, NotTwentyTwo>.of(22)!
+
+both(anotherDouble)
+
+left(anotherDouble)
+
+right(anotherDouble)

--- a/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
@@ -13,18 +13,83 @@ import Prelude
 // Refinement types
 //
 
+// let’s create a very basic `Person` type
+struct Person { var firstName, lastName: String }
+
+// there are some values of this type (eg. both names empty, only a defined `firstName`, etc.) that we probably want to consider invalid data or garbage in some way
+
+// we’ll write a `Refinement` to `Person` that expresses the fact that the names can’t be empty
+enum ValidName: Refinement {
+    typealias BaseType = Person
+    static func isValid(_ value: Person) -> Bool {
+        return !value.firstName.isEmpty && !value.lastName.isEmpty
+    }
+}
+
+// now, let’s put our refinement “rule” and the `Person` type itself into a box to create a new type that enforces our rules:
+typealias ValidPerson = Refined<Person, ValidName>
+
+// here’s a value of type `Person`. Let’s pretend we got it from somewhere else in our application, so we’re not sure whether it’s valid or not…
+let person = Person(firstName: "", lastName: "foo")
+
+// the `ValidPerson` initializer will only successfully `init` if the rule is satisfied:
+try? ValidPerson.init(person) // => nil
+
+try? ValidPerson.init(Person(firstName: "a", lastName: "b")) // => ok
+
+// let’s pretend we have a function that does Important Business Logic with persons
+func doImportantBusinessLogic(with person: Person) {
+    // ensure the person is valid
+    if person.firstName.isEmpty || person.lastName.isEmpty {
+        fatalError("Person data was invalid! I can’t do my important thing")
+    }
+    // do important thing with a valid person here
+}
+
+// we can now refactor this function and the compiler will enforce our rule for us (no more `fatalError` needed)!
+func doImportantBusinessLogic2(with person: ValidPerson) {
+    // names are guaranteed to be valid; do important thing with person here
+}
+
+// just to be clear about that: the following line does not compile…
+//doImportantBusinessLogic2(with: person) // => error: cannot convert value of type 'Person' to expected argument type 'ValidPerson' (aka 'Refined<Person, ValidName>')
+
+// we’ve taken what was a runtime error (`fatalError`), and made it into a compile-time error!
+
+// in a real app, this means fewer “Oops!” boxes, less bailing out of functions when data isn’t right, and less need to document invariants in code comments. Those things go away and are replaced with checks in the type system.
+
+// there’s a problem though. Our rule doesn’t hold for all possible users of our application. What about people who legitimately only have one name? We need another refinement:
+enum PersonIsPrince: Refinement {
+    typealias BaseType = Person
+    static func isValid(_ value: Person) -> Bool {
+        return value.firstName == "Prince" && value.lastName.isEmpty // RIP
+    }
+}
+
+// as long as the `BaseType`s match, we can compose refinements on the fly. The `OneOf` wrapper type creates a refinement that will let a value pass if either the left- **or** right-side refinement passes:
+typealias ValidName2 = OneOf<ValidName, PersonIsPrince>
+
+// now Prince can order a couch again. I won’t bother to write another typealias, here’s the full type inline:
+func doImportantBusinessLogic3(with person: Refined<Person, ValidName2>) {
+    // I hope some purple couches are in stock
+}
+
+// here are some of the basic refinements that are already in the library
 Int.GreaterThanZero.of(1)
 
-Int.GreaterThanZero.of(-99)
-
-Int.GreaterThanZero.of(1) == Int.GreaterThanZero.of(1)
-
-let foo: [Refined<Int, Int.GreaterThanZero>] = [-1, 0, 1, 2, 3].refineMap()
-
-let bar = [-1, 0, 1, 2, 3].refineMap(Int.GreaterThanZero.self)
-
-foo == bar
+Int.GreaterThan<One>.of(-99)
 
 String.NonEmpty.of("foo")
 
 String.NonEmpty.of("")
+
+// conditional conformance of refined types works as expected
+Int.GreaterThanZero.of(1) == Int.GreaterThanZero.of(1)
+
+// to `compactMap` **and** refine at the same time, use `refineMap`
+let bar = [-1, 0, 1, 2, 3].refineMap(Int.GreaterThanZero.self)
+
+// you can also write it like this
+let foo: [Refined<Int, Int.GreaterThanZero>] = [-1, 0, 1, 2, 3].refineMap()
+
+foo == bar

--- a/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
+++ b/Example/Prelude.playground/Pages/refinement-types.xcplaygroundpage/Contents.swift
@@ -13,44 +13,18 @@ import Prelude
 // Refinement types
 //
 
-enum GreaterThanZero: Refinement {
-    typealias RefinedType = Double
-    static func isValid(_ value: Double) -> Bool {
-        return value > 0.0
-    }
-}
+Int.GreaterThanZero.of(1)
 
-GreaterThanZero.of(1)
+Int.GreaterThanZero.of(-99)
 
-GreaterThanZero.of(-99)
+Int.GreaterThanZero.of(1) == Int.GreaterThanZero.of(1)
 
-enum NotTwentyTwo: Refinement {
-    typealias RefinedType = Double
-    static func isValid(_ value: Double) -> Bool {
-        return value != 22.0
-    }
-}
+let foo: [Refined<Int, Int.GreaterThanZero>] = [-1, 0, 1, 2, 3].refineMap()
 
-Both<GreaterThanZero, NotTwentyTwo>.of(22)
+let bar = [-1, 0, 1, 2, 3].refineMap(Int.GreaterThanZero.self)
 
-Both<GreaterThanZero, NotTwentyTwo>.of(-99)
+foo == bar
 
-Both<GreaterThanZero, NotTwentyTwo>.of(100)
+String.NonEmpty.of("foo")
 
-typealias MyRefinedDouble = Refined<Double, Both<GreaterThanZero, NotTwentyTwo>>
-
-try MyRefinedDouble.init(9)
-
-//try MyRefinedDouble.init(22) // will `throw`
-
-let myDouble = MyRefinedDouble.init(9)
-
-left(myDouble)
-
-let anotherDouble = OneOf<GreaterThanZero, NotTwentyTwo>.of(22)!
-
-both(anotherDouble)
-
-left(anotherDouble)
-
-right(anotherDouble)
+String.NonEmpty.of("")

--- a/Example/Prelude.playground/contents.xcplayground
+++ b/Example/Prelude.playground/contents.xcplayground
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' executeOnSourceChanges='false'>
-    <timeline fileName='timeline.xctimeline'/>
+<playground version='6.0' target-platform='ios' executeOnSourceChanges='false'>
+    <pages>
+        <page name='change-tracking'/>
+        <page name='reducers'/>
+        <page name='refinement-types'/>
+    </pages>
 </playground>

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		249A08422226F8860060AE5D /* Refinements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249A08402226F8860060AE5D /* Refinements.swift */; };
 		249EE629222DC02200F93941 /* Nat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249EE628222DC02200F93941 /* Nat.swift */; };
 		249EE62A222DC02200F93941 /* Nat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249EE628222DC02200F93941 /* Nat.swift */; };
+		24F05CFF223074E3003502D0 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F05CFE223074E3003502D0 /* Predicate.swift */; };
+		24F05D00223074E3003502D0 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F05CFE223074E3003502D0 /* Predicate.swift */; };
+		24F05D022231581F003502D0 /* PredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F05D012231581F003502D0 /* PredicateTests.swift */; };
+		24F05D032231581F003502D0 /* PredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F05D012231581F003502D0 /* PredicateTests.swift */; };
 		66541CC5217F6698001E088D /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66541CBB217F6698001E088D /* Prelude.framework */; };
 		6657D9B121AFA8960065E051 /* ChangeTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1E1121AC788200DF98C0 /* ChangeTracking.swift */; };
 		6657D9B221AFA8960065E051 /* Monoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1E0E21AC788200DF98C0 /* Monoid.swift */; };
@@ -74,6 +78,8 @@
 		244559F82229775A00CFC0EB /* RefinementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefinementsTests.swift; sourceTree = "<group>"; };
 		249A08402226F8860060AE5D /* Refinements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refinements.swift; sourceTree = "<group>"; };
 		249EE628222DC02200F93941 /* Nat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nat.swift; sourceTree = "<group>"; };
+		24F05CFE223074E3003502D0 /* Predicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Predicate.swift; sourceTree = "<group>"; };
+		24F05D012231581F003502D0 /* PredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredicateTests.swift; sourceTree = "<group>"; };
 		66541CBB217F6698001E088D /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		66541CC4217F6698001E088D /* PreludeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PreludeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6657D9A721AFA0B80065E051 /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -161,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				66FE1E1C21AC78A900DF98C0 /* ChangeTrackingTests.swift */,
+				24F05D012231581F003502D0 /* PredicateTests.swift */,
 				66FE1E1E21AC78A900DF98C0 /* PreludeTests.swift */,
 				66FE1E1F21AC78A900DF98C0 /* ReducersTests.swift */,
 				244559F82229775A00CFC0EB /* RefinementsTests.swift */,
@@ -224,6 +231,7 @@
 				66FE1E0E21AC788200DF98C0 /* Monoid.swift */,
 				249EE628222DC02200F93941 /* Nat.swift */,
 				66FE1E1021AC788200DF98C0 /* Operators.swift */,
+				24F05CFE223074E3003502D0 /* Predicate.swift */,
 				66FE1E1321AC788200DF98C0 /* Prelude.h */,
 				66FE1E0F21AC788200DF98C0 /* Prelude.swift */,
 				66FE1E1221AC788200DF98C0 /* Reducers.swift */,
@@ -441,6 +449,7 @@
 				66FE1E1621AC788200DF98C0 /* Prelude.swift in Sources */,
 				249A08412226F8860060AE5D /* Refinements.swift in Sources */,
 				66FE1E1721AC788200DF98C0 /* Operators.swift in Sources */,
+				24F05CFF223074E3003502D0 /* Predicate.swift in Sources */,
 				249EE629222DC02200F93941 /* Nat.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -454,6 +463,7 @@
 				66FE1E2321AC78A900DF98C0 /* ReducersTests.swift in Sources */,
 				244559F92229775A00CFC0EB /* RefinementsTests.swift in Sources */,
 				66FE1E2221AC78A900DF98C0 /* PreludeTests.swift in Sources */,
+				24F05D022231581F003502D0 /* PredicateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -468,6 +478,7 @@
 				6657D9B221AFA8960065E051 /* Monoid.swift in Sources */,
 				249A08422226F8860060AE5D /* Refinements.swift in Sources */,
 				6657D9B321AFA8960065E051 /* Operators.swift in Sources */,
+				24F05D00223074E3003502D0 /* Predicate.swift in Sources */,
 				249EE62A222DC02200F93941 /* Nat.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -481,6 +492,7 @@
 				6657D9C721AFA99B0065E051 /* ChangeTrackingTests.swift in Sources */,
 				244559FA2229775A00CFC0EB /* RefinementsTests.swift in Sources */,
 				6657D9C821AFA99B0065E051 /* PreludeTests.swift in Sources */,
+				24F05D032231581F003502D0 /* PredicateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		244559FA2229775A00CFC0EB /* RefinementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244559F82229775A00CFC0EB /* RefinementsTests.swift */; };
 		249A08412226F8860060AE5D /* Refinements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249A08402226F8860060AE5D /* Refinements.swift */; };
 		249A08422226F8860060AE5D /* Refinements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249A08402226F8860060AE5D /* Refinements.swift */; };
+		249EE629222DC02200F93941 /* Nat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249EE628222DC02200F93941 /* Nat.swift */; };
+		249EE62A222DC02200F93941 /* Nat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249EE628222DC02200F93941 /* Nat.swift */; };
 		66541CC5217F6698001E088D /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66541CBB217F6698001E088D /* Prelude.framework */; };
 		6657D9B121AFA8960065E051 /* ChangeTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1E1121AC788200DF98C0 /* ChangeTracking.swift */; };
 		6657D9B221AFA8960065E051 /* Monoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1E0E21AC788200DF98C0 /* Monoid.swift */; };
@@ -71,6 +73,7 @@
 /* Begin PBXFileReference section */
 		244559F82229775A00CFC0EB /* RefinementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefinementsTests.swift; sourceTree = "<group>"; };
 		249A08402226F8860060AE5D /* Refinements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refinements.swift; sourceTree = "<group>"; };
+		249EE628222DC02200F93941 /* Nat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nat.swift; sourceTree = "<group>"; };
 		66541CBB217F6698001E088D /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		66541CC4217F6698001E088D /* PreludeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PreludeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6657D9A721AFA0B80065E051 /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -219,6 +222,7 @@
 			children = (
 				66FE1E1121AC788200DF98C0 /* ChangeTracking.swift */,
 				66FE1E0E21AC788200DF98C0 /* Monoid.swift */,
+				249EE628222DC02200F93941 /* Nat.swift */,
 				66FE1E1021AC788200DF98C0 /* Operators.swift */,
 				66FE1E1321AC788200DF98C0 /* Prelude.h */,
 				66FE1E0F21AC788200DF98C0 /* Prelude.swift */,
@@ -437,6 +441,7 @@
 				66FE1E1621AC788200DF98C0 /* Prelude.swift in Sources */,
 				249A08412226F8860060AE5D /* Refinements.swift in Sources */,
 				66FE1E1721AC788200DF98C0 /* Operators.swift in Sources */,
+				249EE629222DC02200F93941 /* Nat.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -463,6 +468,7 @@
 				6657D9B221AFA8960065E051 /* Monoid.swift in Sources */,
 				249A08422226F8860060AE5D /* Refinements.swift in Sources */,
 				6657D9B321AFA8960065E051 /* Operators.swift in Sources */,
+				249EE62A222DC02200F93941 /* Nat.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		244559F92229775A00CFC0EB /* RefinementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244559F82229775A00CFC0EB /* RefinementsTests.swift */; };
+		244559FA2229775A00CFC0EB /* RefinementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244559F82229775A00CFC0EB /* RefinementsTests.swift */; };
+		249A08412226F8860060AE5D /* Refinements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249A08402226F8860060AE5D /* Refinements.swift */; };
+		249A08422226F8860060AE5D /* Refinements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249A08402226F8860060AE5D /* Refinements.swift */; };
 		66541CC5217F6698001E088D /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66541CBB217F6698001E088D /* Prelude.framework */; };
 		6657D9B121AFA8960065E051 /* ChangeTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1E1121AC788200DF98C0 /* ChangeTracking.swift */; };
 		6657D9B221AFA8960065E051 /* Monoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1E0E21AC788200DF98C0 /* Monoid.swift */; };
@@ -65,6 +69,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		244559F82229775A00CFC0EB /* RefinementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefinementsTests.swift; sourceTree = "<group>"; };
+		249A08402226F8860060AE5D /* Refinements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refinements.swift; sourceTree = "<group>"; };
 		66541CBB217F6698001E088D /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		66541CC4217F6698001E088D /* PreludeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PreludeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6657D9A721AFA0B80065E051 /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -151,11 +157,12 @@
 		66541CC8217F6698001E088D /* PreludeTests */ = {
 			isa = PBXGroup;
 			children = (
-				79E4CF6C21801D4800273142 /* Supporting Files */,
 				66FE1E1C21AC78A900DF98C0 /* ChangeTrackingTests.swift */,
 				66FE1E1E21AC78A900DF98C0 /* PreludeTests.swift */,
 				66FE1E1F21AC78A900DF98C0 /* ReducersTests.swift */,
+				244559F82229775A00CFC0EB /* RefinementsTests.swift */,
 				66FE1E1D21AC78A900DF98C0 /* SequenceExtensionsTests.swift */,
+				79E4CF6C21801D4800273142 /* Supporting Files */,
 			);
 			path = PreludeTests;
 			sourceTree = "<group>";
@@ -216,6 +223,7 @@
 				66FE1E1321AC788200DF98C0 /* Prelude.h */,
 				66FE1E0F21AC788200DF98C0 /* Prelude.swift */,
 				66FE1E1221AC788200DF98C0 /* Reducers.swift */,
+				249A08402226F8860060AE5D /* Refinements.swift */,
 				66FE1E1421AC788200DF98C0 /* Sequence+Prelude.swift */,
 			);
 			name = Prelude;
@@ -427,6 +435,7 @@
 				66FE1E1B21AC788200DF98C0 /* Sequence+Prelude.swift in Sources */,
 				66FE1E1521AC788200DF98C0 /* Monoid.swift in Sources */,
 				66FE1E1621AC788200DF98C0 /* Prelude.swift in Sources */,
+				249A08412226F8860060AE5D /* Refinements.swift in Sources */,
 				66FE1E1721AC788200DF98C0 /* Operators.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -438,6 +447,7 @@
 				66FE1E2121AC78A900DF98C0 /* SequenceExtensionsTests.swift in Sources */,
 				66FE1E2021AC78A900DF98C0 /* ChangeTrackingTests.swift in Sources */,
 				66FE1E2321AC78A900DF98C0 /* ReducersTests.swift in Sources */,
+				244559F92229775A00CFC0EB /* RefinementsTests.swift in Sources */,
 				66FE1E2221AC78A900DF98C0 /* PreludeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -451,6 +461,7 @@
 				6657D9B721AFA8960065E051 /* Sequence+Prelude.swift in Sources */,
 				6657D9B521AFA8960065E051 /* Prelude.swift in Sources */,
 				6657D9B221AFA8960065E051 /* Monoid.swift in Sources */,
+				249A08422226F8860060AE5D /* Refinements.swift in Sources */,
 				6657D9B321AFA8960065E051 /* Operators.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -462,6 +473,7 @@
 				6657D9CA21AFA99B0065E051 /* SequenceExtensionsTests.swift in Sources */,
 				6657D9C921AFA99B0065E051 /* ReducersTests.swift in Sources */,
 				6657D9C721AFA99B0065E051 /* ChangeTrackingTests.swift in Sources */,
+				244559FA2229775A00CFC0EB /* RefinementsTests.swift in Sources */,
 				6657D9C821AFA99B0065E051 /* PreludeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Prelude/Nat.swift
+++ b/Sources/Prelude/Nat.swift
@@ -22,7 +22,3 @@ public enum Zero: Nat {
 public typealias One = Succ<Zero>
 
 public typealias Two = Succ<Succ<Zero>>
-
-public extension Nat {
-    static var doubleValue: Double { return Double(intValue) }
-}

--- a/Sources/Prelude/Nat.swift
+++ b/Sources/Prelude/Nat.swift
@@ -1,0 +1,28 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
+public protocol Nat {
+    static var intValue: Int { get }
+}
+
+public enum Succ<N: Nat>: Nat {
+    public static var intValue: Int { return N.intValue + 1 }
+}
+
+public enum Zero: Nat {
+    public static var intValue: Int { return 0 }
+}
+
+public typealias One = Succ<Zero>
+
+public typealias Two = Succ<Succ<Zero>>
+
+public extension Nat {
+    static var doubleValue: Double { return Double(intValue) }
+}

--- a/Sources/Prelude/Predicate.swift
+++ b/Sources/Prelude/Predicate.swift
@@ -1,0 +1,62 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
+public struct Predicate<A> {
+    public let contains: (A) -> Bool
+}
+
+// MARK: - set algebra
+
+public extension Predicate {
+    func intersection(_ other: Predicate) -> Predicate {
+        return .init { self.contains($0) && other.contains($0) }
+    }
+
+    func subtracting(_ other: Predicate) -> Predicate {
+        return .init { self.contains($0) && !other.contains($0)
+        }
+    }
+
+    func symmetricDifference(_ other: Predicate) -> Predicate {
+        return .init { element in
+            return self.contains(element) && !other.contains(element) ||
+                !self.contains(element) && other.contains(element)
+        }
+    }
+
+    func union(_ other: Predicate) -> Predicate {
+        return .init { self.contains($0) || other.contains($0) }
+    }
+}
+
+public extension Predicate {
+    var inverse: Predicate<A> {
+        return .init { !self.contains($0) }
+    }
+
+    init<S>(_ sequence: S) where S: Sequence, A: Equatable, A == S.Element {
+        contains = { sequence.contains($0) }
+    }
+
+    func pullback<B>(_ transform: @escaping (B) -> A) -> Predicate<B> {
+        return .init { self.contains(transform($0)) }
+    }
+}
+
+// MARK: - Monoid
+
+extension Predicate: Monoid {
+    public static var empty: Predicate {
+        return .init { _ in true }
+    }
+
+    public static func <>(_ lhs: Predicate, _ rhs: Predicate) -> Predicate {
+        return lhs.intersection(rhs)
+    }
+}

--- a/Sources/Prelude/Predicate.swift
+++ b/Sources/Prelude/Predicate.swift
@@ -36,10 +36,6 @@ public extension Predicate {
         return .init { !self.contains($0) }
     }
 
-    init<S>(_ sequence: S) where S: Sequence, A: Equatable, A == S.Element {
-        contains = { sequence.contains($0) }
-    }
-
     func pullback<B>(_ transform: @escaping (B) -> A) -> Predicate<B> {
         return .init { self.contains(transform($0)) }
     }

--- a/Sources/Prelude/Predicate.swift
+++ b/Sources/Prelude/Predicate.swift
@@ -19,15 +19,11 @@ public extension Predicate {
     }
 
     func subtracting(_ other: Predicate) -> Predicate {
-        return .init { self.contains($0) && !other.contains($0)
-        }
+        return intersection(other.complement)
     }
 
     func symmetricDifference(_ other: Predicate) -> Predicate {
-        return .init { element in
-            return self.contains(element) && !other.contains(element) ||
-                !self.contains(element) && other.contains(element)
-        }
+        return self.subtracting(other).union(other.subtracting(self))
     }
 
     func union(_ other: Predicate) -> Predicate {
@@ -36,7 +32,7 @@ public extension Predicate {
 }
 
 public extension Predicate {
-    var inverse: Predicate<A> {
+    var complement: Predicate<A> {
         return .init { !self.contains($0) }
     }
 

--- a/Sources/Prelude/Prelude.h
+++ b/Sources/Prelude/Prelude.h
@@ -11,4 +11,3 @@
 
 FOUNDATION_EXPORT double PreludeVersionNumber;
 FOUNDATION_EXPORT const unsigned char PreludeVersionString[];
-

--- a/Sources/Prelude/Refinements.swift
+++ b/Sources/Prelude/Refinements.swift
@@ -1,0 +1,136 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
+/// protocol that represents a rule that can be used to “refine” values of type `RefinedType`. Implement the `static Refinement.isValid(_:)` function to describe which values are allowed.
+public protocol Refinement {
+    /// the type being “refined”
+    associatedtype RefinedType
+
+    /// implement this function to describe which values of type `RefinedType` should be allowed
+    ///
+    /// - Parameter value: a value of type `RefinedType`
+    /// - Returns: `true` if this rule should allow `value`
+    static func isValid(_ value: RefinedType) -> Bool
+}
+
+/// error that is thrown when a value fails a refinement. Examine `localizedDescription` to determine the details of the failure
+public struct RefinementError: Error {
+    public let localizedDescription: String
+
+    init(_ localizedDescription: String) {
+        self.localizedDescription = localizedDescription
+    }
+}
+
+/// a container for a “refined” type. The type parameter `A` represents the underlying value (eg. `Int`). The type parameter `R` represents the “refinement” (eg. `NonZero`, `NotNegative`, `GreaterThanFifty`, etc.)
+public struct Refined<A, R: Refinement> where A == R.RefinedType {
+    /// the underlying refined value. This value is guaranteed to satisfy the refinement represented by `R`
+    public let value: A
+
+    /// initialize a `Refined` value with the proposed underlying value `value`. If the value satisfies the rule  represented by `R`, then this initializer will succeed. Otherwise, this initializer will throw a `RefinementError` describing the failure
+    ///
+    /// - Parameter value: the proposed underlying value
+    /// - Throws: a `RefinementError` describing any failure
+    public init(_ value: A) throws {
+        guard R.isValid(value) else {
+            throw RefinementError("the value “\(value)” doesn’t satisfy the refinement “\(R.self)”")
+        }
+        self.value = value
+    }
+}
+
+extension Refined: Equatable where A: Equatable { }
+
+extension Refined: Hashable where A: Hashable { }
+
+public extension Refinement {
+    /// convenient way initialize a value of type `Refined<RefinedType, Self>` given a proposed value. This is equivalent to calling `try? Refined<RefinedType, Self>.init(value)`, but much easier to type
+    ///
+    /// - Parameter value: the proposed value
+    /// - Returns: a value of type `Refined<RefinedType, Self>`, or nil
+    static func of(_ value: RefinedType) -> Refined<RefinedType, Self>? {
+        return try? .init(value)
+    }
+}
+
+// MARK: - Both
+
+/// a refinement that can be used to combine any two other refinements (`L` and `R`), such that they both must pass
+public enum Both<L: Refinement, R: Refinement>: Refinement where L.RefinedType == R.RefinedType {
+    public typealias RefinedType = L.RefinedType
+    public static func isValid(_ value: RefinedType) -> Bool {
+        return L.isValid(value) && R.isValid(value)
+    }
+}
+
+/// given a value that is refined by two rules (`L` and `R`), produce a value that is refined only by the rule on the left (`L`). This function will always succeed (the underlying value has already passed both rules)
+///
+/// - Parameter refined: a value that is refined by two rules
+/// - Returns: the same value, refined only by the rule on the left
+public func left<A, L, R>(_ refined: Refined<A, Both<L, R>>) -> Refined<A, L> {
+    guard let result = L.of(refined.value) else {
+        preconditionFailure("when calling `left(_:)`: the value “\(refined.value)” didn’t satisfy the refinement “\(L.self)”. This shouldn’t happen. Was the value mutated after refinements had already been checked?")
+    }
+    return result
+}
+
+/// given a value that is refined by two rules (`L` and `R`), produce a value that is refined only by the rule on the right (`R`). This function will always succeed (the underlying value has already passed both rules)
+///
+/// - Parameter refined: a value that is refined by two rules
+/// - Returns: the same value, refined only by the rule on the right
+public func right<A, L, R>(_ refined: Refined<A, Both<L, R>>) -> Refined<A, R> {
+    guard let result = R.of(refined.value) else {
+        preconditionFailure("when calling `right(_:)`: the value “\(refined.value)” didn’t satisfy the refinement “\(R.self)”. This shouldn’t happen. Was the value mutated after refinements had already been checked?")
+    }
+    return result
+}
+
+// MARK: - Not
+
+/// a refinement that can be used to invert any other refinement
+public enum Not<R: Refinement>: Refinement {
+    public typealias RefinedType = R.RefinedType
+    public static func isValid(_ value: R.RefinedType) -> Bool {
+        return !R.isValid(value)
+    }
+}
+
+// MARK: - OneOf
+
+/// a refinement that can be used to combine any two other refinements (`L` and `R`), such that either one or the other must pass
+public enum OneOf<L: Refinement, R: Refinement>: Refinement where L.RefinedType == R.RefinedType {
+    public typealias RefinedType = L.RefinedType
+    public static func isValid(_ value: RefinedType) -> Bool {
+        return L.isValid(value) || R.isValid(value)
+    }
+}
+
+/// given a value that is refined by a `OneOf<L, R>` (either the refinement `L`, or the refinement `R`), produce a value that is just refined by `L`. This function returns nil if the underlying value does not satisfy `L`
+///
+/// - Parameter refined: a value that is refined by the disjunction of two rules
+/// - Returns: the same value, refined only by the rule on the left, or nil
+public func left<A, L, R>(_ refined: Refined<A, OneOf<L, R>>) -> Refined<A, L>? {
+    return L.of(refined.value)
+}
+
+/// given a value that is refined by a `OneOf<L, R>` (either the refinement `L`, or the refinement `R`), produce a value that is just refined by `R`. This function returns nil if the underlying value does not satisfy `R`
+///
+/// - Parameter refined: a value that is refined by the disjunction of two rules
+/// - Returns: the same value, refined only by the rule on the right, or nil
+public func right<A, L, R>(_ refined: Refined<A, OneOf<L, R>>) -> Refined<A, R>? {
+    return R.of(refined.value)
+}
+
+/// given a value that is refined by a `OneOf<L, R>` (either the refinement `L`, or the refinement `R`), produce a value that is refined by both (`Both<L, R>`). This function returns nil if the underlying value does not satisfy both `L` and `R`
+///
+/// - Parameter refined: a value that is refined by the disjunction of two rules
+/// - Returns: the same value, refined by both of the rules, or nil
+public func both<A, L, R>(_ refined: Refined<A, OneOf<L, R>>) -> Refined<A, Both<L, R>>? {
+    return Both<L, R>.of(refined.value)
+}

--- a/Sources/Prelude/Refinements.swift
+++ b/Sources/Prelude/Refinements.swift
@@ -163,17 +163,6 @@ public func both<A, L, R>(_ refined: Refined<A, OneOf<L, R>>) -> Refined<A, Both
     return Both<L, R>.of(refined.value)
 }
 
-// MARK: - Array
-
-public extension Array {
-    enum NonEmpty: Refinement {
-        public typealias RefinedType = Array
-        public static func isValid(_ value: [Element]) -> Bool {
-            return !value.isEmpty
-        }
-    }
-}
-
 // MARK: - Int
 
 public extension Int {

--- a/Tests/PreludeTests/PredicateTests.swift
+++ b/Tests/PreludeTests/PredicateTests.swift
@@ -1,0 +1,86 @@
+//
+//  PredicateTests.swift
+//  Prelude
+//
+//  Created by Peter Tomaselli on 3/7/19.
+//
+
+@testable import Prelude
+import XCTest
+
+private let greaterThanTen: Predicate<Int> = .init { $0 > 10 }
+
+private let greaterThanZero: Predicate<Int> = .init { $0 > 0 }
+
+final class PredicateTests: XCTestCase {
+    func testPredicate() {
+        XCTAssertTrue(greaterThanZero.contains(1))
+        XCTAssertFalse(greaterThanZero.contains(-1))
+    }
+
+    func testIntersection() {
+        let myPredicate = greaterThanZero.intersection(greaterThanTen)
+        XCTAssertTrue(myPredicate.contains(11))
+        XCTAssertFalse(myPredicate.contains(9))
+        XCTAssertFalse(myPredicate.contains(-1))
+    }
+
+    func testSubtracting() {
+        let myPredicate = greaterThanZero.subtracting(greaterThanTen)
+        XCTAssertTrue(myPredicate.contains(1))
+        XCTAssertFalse(myPredicate.contains(11))
+        XCTAssertFalse(myPredicate.contains(-1))
+    }
+
+    func testSymmetricDifference() {
+        let lessThanTen: Predicate<Int> = .init { $0 < 10 }
+        let myPredicate = greaterThanZero.symmetricDifference(lessThanTen)
+        XCTAssertTrue(myPredicate.contains(-1))
+        XCTAssertTrue(myPredicate.contains(11))
+        XCTAssertFalse(myPredicate.contains(9))
+    }
+
+    func testUnion() {
+        let oneToFive: Predicate<Int> = .init { 1...5 ~= $0 }
+        let sevenToTen: Predicate<Int> = .init { 7...10 ~= $0 }
+        let myPredicate = oneToFive.union(sevenToTen)
+        XCTAssertTrue(myPredicate.contains(2))
+        XCTAssertTrue(myPredicate.contains(8))
+        XCTAssertFalse(myPredicate.contains(0))
+        XCTAssertFalse(myPredicate.contains(6))
+        XCTAssertFalse(myPredicate.contains(11))
+    }
+
+    func testInverse() {
+        let myPredicate = greaterThanZero.inverse
+        XCTAssertTrue(myPredicate.contains(0))
+        XCTAssertTrue(myPredicate.contains(-1))
+        XCTAssertFalse(myPredicate.contains(1))
+    }
+
+    func testSequenceInitializer() {
+        let myPredicate: Predicate<Int> = .init([1, 2, 3])
+        XCTAssertTrue(myPredicate.contains(1))
+        XCTAssertTrue(myPredicate.contains(2))
+        XCTAssertTrue(myPredicate.contains(3))
+        XCTAssertFalse(myPredicate.contains(0))
+        XCTAssertFalse(myPredicate.contains(4))
+    }
+
+    func testPullback() {
+        let myPredicate: Predicate<String> = greaterThanZero.pullback { $0.count }
+        XCTAssertTrue(myPredicate.contains("foobar"))
+        XCTAssertFalse(myPredicate.contains(""))
+    }
+
+    func testIdentity() {
+        XCTAssertTrue(
+            (greaterThanZero <> .empty).contains(1))
+        XCTAssertFalse(
+            (greaterThanZero <> .empty).contains(-1))
+        XCTAssertTrue(
+            (.empty <> greaterThanZero).contains(1))
+        XCTAssertFalse(
+            (.empty <> greaterThanZero).contains(-1))
+    }
+}

--- a/Tests/PreludeTests/PredicateTests.swift
+++ b/Tests/PreludeTests/PredicateTests.swift
@@ -58,15 +58,6 @@ final class PredicateTests: XCTestCase {
         XCTAssertFalse(myPredicate.contains(1))
     }
 
-    func testSequenceInitializer() {
-        let myPredicate: Predicate<Int> = .init([1, 2, 3])
-        XCTAssertTrue(myPredicate.contains(1))
-        XCTAssertTrue(myPredicate.contains(2))
-        XCTAssertTrue(myPredicate.contains(3))
-        XCTAssertFalse(myPredicate.contains(0))
-        XCTAssertFalse(myPredicate.contains(4))
-    }
-
     func testPullback() {
         let myPredicate: Predicate<String> = greaterThanZero.pullback { $0.count }
         XCTAssertTrue(myPredicate.contains("foobar"))

--- a/Tests/PreludeTests/PredicateTests.swift
+++ b/Tests/PreludeTests/PredicateTests.swift
@@ -52,7 +52,7 @@ final class PredicateTests: XCTestCase {
     }
 
     func testInverse() {
-        let myPredicate = greaterThanZero.inverse
+        let myPredicate = greaterThanZero.complement
         XCTAssertTrue(myPredicate.contains(0))
         XCTAssertTrue(myPredicate.contains(-1))
         XCTAssertFalse(myPredicate.contains(1))

--- a/Tests/PreludeTests/RefinementsTests.swift
+++ b/Tests/PreludeTests/RefinementsTests.swift
@@ -231,24 +231,6 @@ final class RefinementsTests: XCTestCase {
         )
     }
 
-    // MARK: - Array
-
-    func testNonEmptyArrayRefinement() {
-        let arrayOfArrays = [
-            [1],
-            [1, 2, 3],
-            [],
-            [0],
-            []
-        ]
-
-        XCTAssertEqual(
-            [[1], [1, 2, 3], [0]],
-            arrayOfArrays
-                .refineMap(Array.NonEmpty.self)
-                .map { $0.value })
-    }
-
     // MARK: - Int
 
     func testIntComparisonRefinements() {

--- a/Tests/PreludeTests/RefinementsTests.swift
+++ b/Tests/PreludeTests/RefinementsTests.swift
@@ -1,0 +1,199 @@
+//
+// This source file is part of Prelude, an open source project by Wayfair
+//
+// Copyright (c) 2018 Wayfair, LLC.
+// Licensed under the 2-Clause BSD License
+//
+// See LICENSE.md for license information
+//
+
+@testable import Prelude
+import XCTest
+
+private enum NonZero: Refinement {
+    typealias RefinedType = Int
+    static func isValid(_ value: Int) -> Bool {
+        return value != 0
+    }
+}
+
+private enum NotTwentyTwo: Refinement {
+    typealias RefinedType = Int
+    static func isValid(_ value: Int) -> Bool {
+        return value != 22
+    }
+}
+
+private enum IsPositive: Refinement {
+    typealias RefinedType = Int
+    static func isValid(_ value: Int) -> Bool {
+        return value > 0
+    }
+}
+
+private enum IsNegative: Refinement {
+    typealias RefinedType = Int
+    static func isValid(_ value: Int) -> Bool {
+        return value < 0
+    }
+}
+
+private typealias NonZeroInt = Refined<Int, NonZero>
+
+final class RefinementsTests: XCTestCase {
+    func testInitializeRefinedValue() {
+        XCTAssertNoThrow(
+            try NonZeroInt.init(1)
+        )
+    }
+
+    func testInitializeRefinedValueThrows() {
+        XCTAssertThrowsError(try NonZeroInt.init(0), "what is this parameter for anyway") { error in
+            XCTAssertTrue(error is RefinementError)
+        }
+    }
+
+    func testRefinementOfFunctionSucceeds() {
+        XCTAssertNotNil(
+            NonZero.of(1)
+        )
+    }
+
+    func testRefinementOfFunctionFails() {
+        XCTAssertNil(
+            NonZero.of(0)
+        )
+    }
+
+    // MARK: - Both
+
+    func testRefinementOfFunctionSucceeds_both() {
+        XCTAssertNotNil(
+            Both<NonZero, NotTwentyTwo>.of(1)
+        )
+    }
+
+    func testRefinementOfFunctionFails_both() {
+        XCTAssertNil(
+            Both<NonZero, NotTwentyTwo>.of(0)
+        )
+
+        XCTAssertNil(
+            Both<NonZero, NotTwentyTwo>.of(22)
+        )
+    }
+
+    func testRefinementBoth_leftFunctionSucceeds() {
+        guard let both = Both<NonZero, NotTwentyTwo>.of(1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+        let _: Refined<Int, NonZero> = left(both)
+    }
+
+    func testRefinementBoth_rightFunctionSucceeds() {
+        guard let both = Both<NonZero, NotTwentyTwo>.of(1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+        let _: Refined<Int, NotTwentyTwo> = right(both)
+    }
+
+    // MARK: - Not
+
+    func testRefinementOfFunctionSucceeds_not() {
+        XCTAssertNotNil(
+            Not<NotTwentyTwo>.of(22)
+        )
+    }
+
+    func testRefinementOfFunctionFails_not() {
+        XCTAssertNil(
+            Not<NotTwentyTwo>.of(1)
+        )
+    }
+
+    // MARK: - OneOf
+
+    func testRefinementOfFunctionSucceeds_oneOf() {
+        XCTAssertNotNil(
+            OneOf<IsPositive, IsNegative>.of(1)
+        )
+
+        XCTAssertNotNil(
+            OneOf<IsPositive, IsNegative>.of(-1)
+        )
+    }
+
+    func testRefinementOfFunctionFails_oneOf() {
+        XCTAssertNil(
+            OneOf<IsPositive, IsNegative>.of(0)
+        )
+    }
+
+    func testRefinementOneOf_leftFunctionSucceeds() {
+        guard let oneOf = OneOf<IsPositive, IsNegative>.of(1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+
+        XCTAssertNotNil(
+            left(oneOf)
+        )
+    }
+
+    func testRefinementOneOf_leftFunctionFails() {
+        guard let oneOf = OneOf<IsPositive, IsNegative>.of(-1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+
+        XCTAssertNil(
+            left(oneOf)
+        )
+    }
+
+    func testRefinementOneOf_rightFunctionSucceeds() {
+        guard let oneOf = OneOf<IsPositive, IsNegative>.of(-1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+
+        XCTAssertNotNil(
+            right(oneOf)
+        )
+    }
+
+    func testRefinementOneOf_rightFunctionFails() {
+        guard let oneOf = OneOf<IsPositive, IsNegative>.of(1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+
+        XCTAssertNil(
+            right(oneOf)
+        )
+    }
+
+    func testRefinementOneOf_bothFunctionSucceeds() {
+        guard let oneOf = OneOf<IsPositive, NotTwentyTwo>.of(1) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+
+        XCTAssertNotNil(
+            both(oneOf)
+        )
+    }
+
+    func testRefinementOneOf_bothFunctionFails() {
+        guard let oneOf = OneOf<IsPositive, NotTwentyTwo>.of(22) else {
+            XCTFail("this should have succeeded")
+            return
+        }
+
+        XCTAssertNil(
+            both(oneOf)
+        )
+    }
+}

--- a/Tests/PreludeTests/RefinementsTests.swift
+++ b/Tests/PreludeTests/RefinementsTests.swift
@@ -231,6 +231,24 @@ final class RefinementsTests: XCTestCase {
         )
     }
 
+    // MARK: - Array
+
+    func testNonEmptyArrayRefinement() {
+        let arrayOfArrays = [
+            [1],
+            [1, 2, 3],
+            [],
+            [0],
+            []
+        ]
+
+        XCTAssertEqual(
+            [[1], [1, 2, 3], [0]],
+            arrayOfArrays
+                .refineMap(Array.NonEmpty.self)
+                .map { $0.value })
+    }
+
     // MARK: - Int
 
     func testIntComparisonRefinements() {

--- a/Tests/PreludeTests/RefinementsTests.swift
+++ b/Tests/PreludeTests/RefinementsTests.swift
@@ -65,6 +65,40 @@ final class RefinementsTests: XCTestCase {
         )
     }
 
+    func testNarrow() {
+        let compute: (Int) -> String = { return "\($0 + 1)" }
+        let narrowed = IsPositive.narrow(compute)
+
+        var result: String?
+        if let refined = IsPositive.of(99) {
+            result = narrowed(refined)
+        }
+
+        XCTAssertEqual("100", result)
+    }
+
+    // MARK: - Equatable
+
+    func testMakeSureEquatableThingsAreEquatable() {
+        XCTAssertEqual(NonZero.of(1), NonZero.of(1))
+    }
+
+    // MARK: - Sequence
+
+    func testRefineMap() {
+        var expected = [Refined<Int, IsPositive>]()
+        do {
+            expected.append(try .init(1))
+            expected.append(try .init(2))
+            expected.append(try .init(3))
+        } catch {
+            XCTFail("shouldn’t get here")
+        }
+        XCTAssertEqual(
+            expected,
+            [-2, -1, 0, 1, 2, 3].refineMap(IsPositive.self))
+    }
+
     // MARK: - Both
 
     func testRefinementOfFunctionSucceeds_both() {
@@ -195,5 +229,52 @@ final class RefinementsTests: XCTestCase {
         XCTAssertNil(
             both(oneOf)
         )
+    }
+
+    // MARK: - Int
+
+    func testIntComparisonRefinements() {
+        let array = [-2, -1, 0, 1, 2, 3, 4, 5]
+
+        XCTAssertEqual(
+            [3, 4, 5],
+            array
+                .refineMap(Int.GreaterThan<Two>.self)
+                .map { $0.value })
+        XCTAssertEqual(
+            [2, 3, 4, 5],
+            array
+                .refineMap(Int.GreaterThanOrEqual<Two>.self)
+                .map { $0.value })
+        XCTAssertEqual(
+            [1, 2, 3, 4, 5],
+            array
+                .refineMap(Int.GreaterThanZero.self)
+                .map { $0.value })
+        XCTAssertEqual(
+            [-2, -1, 0, 1],
+            array
+                .refineMap(Int.LessThan<Two>.self)
+                .map { $0.value })
+        XCTAssertEqual(
+            [-2, -1, 0, 1, 2],
+            array
+                .refineMap(Int.LessThanOrEqual<Two>.self)
+                .map { $0.value })
+        XCTAssertEqual(
+            [-2, -1],
+            array
+                .refineMap(Int.LessThanZero.self)
+                .map { $0.value })
+    }
+
+    // MARK: - String
+
+    func testNonEmptyStringRefinement() {
+        let array = ["foo", "bar", "", "baz", "", "qux"]
+
+        XCTAssertEqual(
+            ["foo", "bar", "baz", "qux"],
+            array.refineMap(String.NonEmpty.self).map { $0.value })
     }
 }


### PR DESCRIPTION
# Refinement types!
  * add `Refinements.swift`
    * basic refinements included: `Array.NonEmpty`, `String.NonEmpty`, `Int.GreaterThan`, `Int.GreaterThanOrEqual`, `Int.*Than…` (the rest of the `Int` ones)
    * add `RefinementsTests.swift`
    * add a playgroundpage for them
  * add `Nat.swift` (“type-level” natural numbers)
  * add `Predicate.swift` (predicates — ways of filtering values — with set-like operations: `union`, `intersection`, etc.)
    * add `PredicateTests.swift`
  * break the other playgroundpages up instead of having one huge one

# What it
“Refinement types” (name chosen based on some [prior art](https://nikita-volkov.github.io/refined/) in [other libraries](https://hackage.haskell.org/package/refined-0.3.0.0/docs/Refined.html)) are a way to add validation or other checks to existing types in a compositional way. 

You can think of this as easily being able to “filter” values based on certain checks, with one important difference: after a value has been refined it has a _different type_ that denotes the refinement that was applied.

This means that you can use the compiler to ensure that certain validation is applied to values before you do anything with them. For example, this function…
```swift
func divide(_ dividend: Double, by divisor: Double) -> Double { … } // danger: divide by zero
```
can be refactored into the function…
```swift
func divide(_ dividend: Double, by divisor: NonZeroDouble) -> Double { … }
```
to guard against the division by zero error, and the check against zero (the `NonZeroDouble` part) can be pushed out to the caller (Note that if you try and call the above function with a plain `Double`, the compiler won’t let you). In general this allows us to push checks like this to the boundaries of the program, and the compiler will enforce the fact that callers perform the checks we specify.

# How it
To implement a refinement (*think: rule*), one must write a type that conforms to the `Refinement` protocol. This type is never instantiated, so an uninhabited `enum` can be used. For example:
```swift
enum IsPositive: Refinement {
    typealias RefinedType = Int
    static func isValid(_ value: Int) -> Bool {
        return value > 0
    }
}
```
To use the refinement, one should attempt to initialized a `Refined` struct (*think: container*) with it. That looks like this:
```swift
let foo = try Refined<Int, IsPositive>.init(1)
```
This `init` will `throw` if the refinement doesn’t pass.

This `init` is somewhat verbose, and thrown errors are also sometimes a nuisance, so an alternate way to construct the same value is to use the `of(_:)` `static` method on the refinement itself. Note that this method is _on the refinement_ (rule), not on the `Refined` container type. It looks like this:
```swift
let foo2 = IsPositive.of(1)
```
`of(_:)` returns an optional, so it’s an ideal syntax for `if let…` or `guard let…` blocks:
```swift
if let divisor = NonZero.of(someDouble) { // `divisor` becomes the type `Refined<Double, NonZero>`
  divide(123.0, by: divisor) // call the `divide` example from the beginning
}
```

# Compose it
Once you reify the idea of a refinement “rule” into a type, it’s relatively easy to write types that create rules out of other rules. This PR includes:
```swift
/// a refinement that can be used to combine any two other refinements (`L` and `R`),
/// such that they both must pass
public enum Both<L: Refinement, R: Refinement>: Refinement where L.RefinedType == R.RefinedType { … }
```
```swift
/// a refinement that can be used to invert any other refinement
public enum Not<R: Refinement>: Refinement { … }
```
and
```swift
/// a refinement that can be used to combine any two other refinements (`L` and `R`), 
/// such that either one or the other must pass
public enum OneOf<L: Refinement, R: Refinement>: Refinement where L.RefinedType == R.RefinedType { … }
```
It’d be nice if there were a way to establish a genuine subtype relationship between eg. `Refined<Int, Both<GreaterThanFifty, LessThanOneHundred>>` and `Refined<Int, GreaterThanFifty>` (in other words, make usage of `Both` work seamlessly when only one or the other of the rules is required), but I don’t think that is possible. 

Instead, this PR provides overloads of functions named `left`, `right`, and `both` to “promote” and “demote” values as needed. In practice this probably will not be done very frequently.

Under the hood refinements are combined using a `Predicate` struct (that represents a “filter-style” rule) with `Set`-like operations (`union`, `intersection`, etc.). Credit to @simonpierreroy1’s for this idea!