### PR TITLE
Adding composition operator (>>>)

### DIFF
--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -46,8 +46,8 @@ precedencegroup WayfairPipe {
 infix operator |>: WayfairPipe
 
 precedencegroup WayfairCompose {
-    associativity: left
-    higherThan: LogicalConjunctionPrecedence
+    associativity: right
+    higherThan: WayfairPipe
 }
 
 /// Definition can be found in /Sources/Prelude.swift

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -45,6 +45,14 @@ precedencegroup WayfairPipe {
 /// Definition can be found in /Sources/Prelude.swift
 infix operator |>: WayfairPipe
 
+precedencegroup WayfairCompose {
+    associativity: left
+    higherThan: LogicalConjunctionPrecedence
+}
+
+/// Definition can be found in /Sources/Prelude.swift
+infix operator >>>: WayfairCompose
+
 // MARK: - right associative
 
 /// in Haskell: `infixr 6`

--- a/Sources/Prelude/Prelude.swift
+++ b/Sources/Prelude/Prelude.swift
@@ -38,6 +38,6 @@ public func |><A, B>(lhs: A, rhs: (A) -> B) -> B {
 /// The compose operator ">>>" provides an infix notation for function composition.
 /// Composing a function that goes from A -> B with a function that goes from B -> C
 /// creates a new function that goes from A -> C.
-public func >>><A, B, C>(f: @escaping (A) -> B, g: @escaping (B) -> C) -> ((A) -> C) {
-    return { a in g(f(a)) }
+public func >>><A, B, C>(lhs: @escaping (A) -> B, rhs: @escaping (B) -> C) -> (A) -> C {
+    return { a in rhs(lhs(a)) }
 }

--- a/Sources/Prelude/Prelude.swift
+++ b/Sources/Prelude/Prelude.swift
@@ -34,3 +34,10 @@ public func flip<A, B, C>(_ f: @escaping (A, B) -> C) -> (B, A) -> C {
 public func |><A, B>(lhs: A, rhs: (A) -> B) -> B {
     return rhs(lhs)
 }
+
+/// The compose operator ">>>" provides an infix notation for function composition.
+/// Composing a function that goes from A -> B with a function that goes from B -> C
+/// creates a new function that goes from A -> C.
+public func >>><A, B, C>(f: @escaping (A) -> B, g: @escaping (B) -> C) -> ((A) -> C) {
+    return { a in g(f(a)) }
+}

--- a/Tests/PreludeTests/PreludeTests.swift
+++ b/Tests/PreludeTests/PreludeTests.swift
@@ -10,22 +10,23 @@
 @testable import Prelude
 import XCTest
 
+func increment(_ value: Double) -> Double {
+    return value + 1
+}
+
+func double(_ value: Double) -> Double {
+    return value + value
+}
+
+func square(_ value: Double) -> Double {
+    return value * value
+}
+
+func strAppend(_ toAppend: String) -> (String) -> String {
+    return { $0 + toAppend }
+}
+
 final class PipeForwardTests: XCTestCase {
-    func increment(_ value: Double) -> Double {
-        return value + 1
-    }
-
-    func double(_ value: Double) -> Double {
-        return value + value
-    }
-
-    func square(_ value: Double) -> Double {
-        return value * value
-    }
-
-    func strAppend(_ toAppend: String) -> (String) -> String {
-        return { $0 + toAppend }
-    }
 
     func testDouble() {
         let incDoubleSquareFive = 5
@@ -46,17 +47,13 @@ final class PipeForwardTests: XCTestCase {
 
 final class ComposeTests: XCTestCase {
 
-    static func increment(_ value: Double) -> Double {
-        return value + 1
-    }
-
-    static func double(_ value: Double) -> Double {
-        return value + value
-    }
-
     let doubleThenIncrement = double >>> increment
 
     let incrementThenDouble = increment >>> double
+
+    let incrementThenDoubleThenSquare = increment >>> double >>> square
+
+    let squareThenIncrementThenDouble = square >>> increment >>> double
 
     func testDoubleThenIncrement() {
         XCTAssertEqual(3 * 2 + 1, doubleThenIncrement(3))
@@ -64,5 +61,29 @@ final class ComposeTests: XCTestCase {
 
     func testIncrementThenDouble() {
         XCTAssertEqual((3 + 1) * 2, incrementThenDouble(3))
+    }
+
+    func testIncrementDoubleSquare() {
+        let value: Double = 3
+        let incrementedValue = increment(value)
+        let incrementedDoubledValue = double(incrementedValue)
+        let incrementedDoubledSquaredValue = square(incrementedDoubledValue)
+
+        XCTAssertEqual(incrementedDoubledSquaredValue, incrementThenDoubleThenSquare(value))
+    }
+
+    func testSquareIncrementDouble() {
+        let value: Double = 3
+        let squaredValue = square(value)
+        let squaredIncrementedValue = increment(squaredValue)
+        let squaredIncrementedDoubledValue = double(squaredIncrementedValue)
+
+        XCTAssertEqual(squaredIncrementedDoubledValue, squareThenIncrementThenDouble(value))
+    }
+
+    func testPrecedenceWithPipe() {
+        let fiveIncrementThenDouble = 5 |> increment >>> double
+
+        XCTAssertEqual(fiveIncrementThenDouble, (5 + 1) * 2)
     }
 }

--- a/Tests/PreludeTests/PreludeTests.swift
+++ b/Tests/PreludeTests/PreludeTests.swift
@@ -43,3 +43,26 @@ final class PipeForwardTests: XCTestCase {
         XCTAssertEqual(" abc", appendingString)
     }
 }
+
+final class ComposeTests: XCTestCase {
+
+    static func increment(_ value: Double) -> Double {
+        return value + 1
+    }
+
+    static func double(_ value: Double) -> Double {
+        return value + value
+    }
+
+    let doubleThenIncrement = double >>> increment
+
+    let incrementThenDouble = increment >>> double
+
+    func testDoubleThenIncrement() {
+        XCTAssertEqual(3 * 2 + 1, doubleThenIncrement(3))
+    }
+
+    func testIncrementThenDouble() {
+        XCTAssertEqual((3 + 1) * 2, incrementThenDouble(3))
+    }
+}


### PR DESCRIPTION
The compose operator ">>" provides an infix notation for function composition.
Composing a function that goes from A -> B with a function that goes from B -> C creates a new function that goes from A -> C.

Also added a tests.