### PR TITLE
WIP: add support for reducers that return effects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: swift
-osx_image: xcode10.2
+osx_image: xcode11.2
 xcode_project: Prelude.xcodeproj
 
 matrix:
   include:
     - xcode_scheme: Prelude iOS
-      xcode_destination: platform=iOS Simulator,OS=12.2,name=iPhone XS
+      xcode_destination: platform=iOS Simulator,OS=13.2,name=iPhone 11
     - xcode_scheme: Prelude macOS
       xcode_destination: platform=OS X,arch=x86_64

--- a/Sources/Prelude/Reducers.swift
+++ b/Sources/Prelude/Reducers.swift
@@ -7,31 +7,98 @@
 // See LICENSE.md for license information
 //
 
-/// a struct that wraps a function suitable for passing to the `updateAccumulatingResult:` parameter of `Sequence.reduce(into:_:)`
-public struct Reducer<A, X> {
-    public let updateAccumulatingResult: (inout A, X) -> Void
+// MARK: - reducers that can return effects
 
-    public init(_ updateAccumulatingResult: @escaping (inout A, X) -> Void) {
+public struct ReducerE<A, X, E> {
+    public let updateAccumulatingResult: (inout A, X) -> E
+
+    public init(_ updateAccumulatingResult: @escaping (inout A, X) -> E) {
         self.updateAccumulatingResult = updateAccumulatingResult
     }
 }
 
-public extension Reducer {
-    /// get this reducer’s reduction function in “immutable” form (for example, to pass it to `Sequence.reduce(_:_:)`)
-    var next: (A, X) -> A {
+public extension ReducerE {
+    /// get this reducer’s reduction function in “immutable” form
+    var next: (A, X) -> (A, E) {
         return { result, element in
             var copy = result
-            self.updateAccumulatingResult(&copy, element)
-            return copy
+            let effect = self.updateAccumulatingResult(&copy, element)
+            return (copy, effect)
         }
+    }
+
+    /// create a new reducer based on an “immutable” reduction function — a function where the accumulator is not mutable. When possible, create “mutable”/`inout` reducers instead, using the `ReducerE` initializer
+    ///
+    /// - Parameter nextPartialResult: a reduction function where the accumulator is immutable
+    /// - Returns: a `Reducer` wrapping that function
+    static func nextPartialResult(_ nextPartialResult: @escaping (A, X) -> (A, E)) -> ReducerE {
+        .init { result, element in
+            let (step, effect) = nextPartialResult(result, element)
+            result = step
+            return effect
+        }
+    }
+
+    /// pullback (contravariant `map`) for reducers. Given a reducer that consumes values of type `X`, and a transform function `(Y) -> X`, return a new reducer that consumes values of type `Y`
+    ///
+    /// - Parameter transform: a transform function of the type `(Y) -> X`
+    /// - Returns: a new reducer that consumes values of type `Y`
+    func pullback<Y>(_ transform: @escaping (Y) -> X) -> ReducerE<A, Y, E> {
+        .init { result, element in
+            self.updateAccumulatingResult(&result, transform <| element)
+        }
+    }
+}
+
+extension ReducerE: Semigroup where E: Semigroup {
+    /// `Semigroup` combine for reducers. Two reducers could be said to be combined by wrapping them in a new reducer that runs each of their reduction operations in sequence
+    ///
+    /// - Parameters:
+    ///   - lhs: a reducer
+    ///   - rhs: another reducer
+    /// - Returns: a reducer that for each input, first runs `lhs`, then runs `rhs`
+    public static func <>(_ lhs: ReducerE, _ rhs: ReducerE) -> ReducerE {
+        .init { result, element in
+            lhs.updateAccumulatingResult(&result, element)
+                <> rhs.updateAccumulatingResult(&result, element)
+        }
+    }
+}
+
+extension ReducerE: Monoid where E: Monoid {
+    /// the identity `Reducer`. This reducer ignores its parameters, performs no mutation to the accumulator, and returns the empty effect
+    public static var empty: ReducerE {
+        .init { _, _ in .empty }
+    }
+}
+
+// MARK: - reducers without effects
+
+/// a struct that wraps a function suitable for passing to the `updateAccumulatingResult:` parameter of `Sequence.reduce(into:_:)`
+public struct Reducer<A, X> {
+    fileprivate let innerReducer: ReducerE<A, X, Void>
+}
+
+public extension Reducer {
+    init(_ updateAccumulatingResult: @escaping (inout A, X) -> Void) {
+        self.innerReducer = .init(updateAccumulatingResult)
+    }
+
+    /// get this reducer’s reduction function in “immutable” form (for example, to pass it to `Sequence.reduce(_:_:)`)
+    var next: (A, X) -> A {
+        return { self.innerReducer.next($0, $1).0 }
+    }
+
+    var updateAccumulatingResult: (inout A, X) -> Void {
+        innerReducer.updateAccumulatingResult
     }
 
     /// create a new reducer based on an “immutable” reduction function — a function where the accumulator is not mutable. When possible, create “mutable”/`inout` reducers instead, using the `Reducer` initializer
     ///
     /// - Parameter nextPartialResult: a reduction function where the accumulator is immutable
     /// - Returns: a `Reducer` wrapping that function
-    static func nextPartialResult(_ nextPartialResult: @escaping (A, X) -> A) -> Reducer<A, X> {
-        return .init { result, element in
+    static func nextPartialResult(_ nextPartialResult: @escaping (A, X) -> A) -> Reducer {
+        .init { result, element in
             result = nextPartialResult(result, element)
         }
     }
@@ -42,8 +109,8 @@ public extension Reducer {
     ///
     /// - Parameter nextReducer: the reducer to “append” to this one
     /// - Returns: a new reducer that performs the effects of `self` and `nextReducer` in sequence
-    func followed(by nextReducer: Reducer<A, X>) -> Reducer<A, X> {
-        return .init { result, element in
+    func followed(by nextReducer: Reducer) -> Reducer {
+        .init { result, element in
             self.updateAccumulatingResult(&result, element)
             nextReducer.updateAccumulatingResult(&result, element)
         }
@@ -54,9 +121,7 @@ public extension Reducer {
     /// - Parameter transform: a transform function of the type `(Y) -> X`
     /// - Returns: a new reducer that consumes values of type `Y`
     func pullback<Y>(_ transform: @escaping (Y) -> X) -> Reducer<A, Y> {
-        return .init { result, element in
-            return self.updateAccumulatingResult(&result, transform(element))
-        }
+        .init(innerReducer: innerReducer.pullback(transform))
     }
 }
 
@@ -72,8 +137,8 @@ public extension Sequence {
 
 extension Reducer: Monoid {
     /// the identity `Reducer`. This reducer ignores its parameters and performs no mutation to the accumulator
-    public static var empty: Reducer<A, X> {
-        return .init { _, _ in }
+    public static var empty: Reducer {
+        .init { _, _ in }
     }
 
     /// `Semigroup` combine for reducers. Two reducers could be said to be combined by wrapping them in a new reducer that runs each of their reduction operations in sequence
@@ -82,7 +147,7 @@ extension Reducer: Monoid {
     ///   - lhs: a reducer
     ///   - rhs: another reducer
     /// - Returns: a reducer that for each input, first runs `lhs`, then runs `rhs`
-    public static func <><A, X>(_ lhs: Reducer<A, X>, _ rhs: Reducer<A, X>) -> Reducer<A, X> {
-        return lhs.followed(by: rhs)
+    public static func <>(_ lhs: Reducer, _ rhs: Reducer) -> Reducer {
+        lhs.followed(by: rhs)
     }
 }


### PR DESCRIPTION
Add support for `Reducer`s that return effects, in the style of Elm, Redux, and Point-Free’s recent “Composable Architecture” series.

This PR adds a new `ReducerE` type, which is just a reducer that returns an effect type `E`. We can maintain the existing public API of `Reducer` by just reimplementing `Reducer` as struct that holds a `ReducerE` that has `E` fixed to `Void`. 

Most of the existing reducer composition operations we have continue to work for `ReducerE`, and if `E` is a `Monoid`, they all work. Unfortunately `Void` is a non-nominal type in Swift and so we can’t implement `Reducer` entirely in terms of `ReducerE`, because we can’t make `Void` a `Monoid`. 

We could instead try and make `Reducer` a `typealias` to `ReducerE<A, X, Void>`, as opposed to a wrapper, but that would be a breaking change to the public API because there would be annoying tuples returned in places.