### PR TITLE
Disable code coverage

### DIFF
--- a/Prelude.xcodeproj/xcshareddata/xcschemes/Prelude-Package.xcscheme
+++ b/Prelude.xcodeproj/xcshareddata/xcschemes/Prelude-Package.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Disable code coverage on the test scheme to work around an issue similar to [this one](https://github.com/ReactiveCocoa/ReactiveSwift/issues/552).

See also [this Q&A](https://developer.apple.com/library/archive/qa/qa1964/_index.html) which includes helpful `otool` commands for diagnosing this.

We should tag this as `0.6.1` and release since consumers don’t need code coverage data from us anyway. This is annoying though!