### PR TITLE
Tagged queues

### DIFF
--- a/Prelude.playground/Pages/laters.xcplaygroundpage/Contents.swift
+++ b/Prelude.playground/Pages/laters.xcplaygroundpage/Contents.swift
@@ -164,3 +164,7 @@ AnyLater<(Float, Void, [Double])> { $0((1.0, (), [])) }
 //
 
 // TODO
+
+//
+//
+//

--- a/Prelude.playground/Pages/laters.xcplaygroundpage/Contents.swift
+++ b/Prelude.playground/Pages/laters.xcplaygroundpage/Contents.swift
@@ -101,7 +101,8 @@ func myAsyncFunc(completion: @escaping () -> Void) {
 }
 
 // there are initializers for `AnyLater` that should be sufficient to “capture” any plain, callback-taking function and convert it to a `Later` in one step:
-let a = AnyLater(myAsyncFunc).run {
+let a = AnyLater(myAsyncFunc)
+a.run {
     print("ok")
 }
 
@@ -163,8 +164,73 @@ AnyLater<(Float, Void, [Double])> { $0((1.0, (), [])) }
 // create a bunch of interdependent `NSOperation`s zone
 //
 
-// TODO
+var first = false
+var second = false
+
+// since a `Later` is an asynchronous blob of code that does nothing until we run it, we can write an operator (`.asOperation()`) to bridge between the world of Laters and the world of Foundation `NSOperations`…
+let firstOperation = sendTrue
+    .tap { first = $0 }
+    .map { _ in () }
+    .asOperation()
+
+let secondOperation = Laters.After(deadline: .now() + 2, queue: .main, value: true)
+    .tap { second = $0 }
+    .map { _ in () }
+    .asOperation()
+
+let lastOperation = Laters.After(deadline: .now(), queue: .main, value: ())
+    .tap { _ in print("first: \(first)") }
+    .tap { _ in print("second: \(second)") }
+    .asOperation()
+
+// once you’ve converted a `Later` into an `Operation`, you can use the more elaborate features of `Operation`s on top of the work you already expressed inside the original Laters. Here’re some dependencies…
+lastOperation.addDependency(firstOperation)
+lastOperation.addDependency(secondOperation)
+
+// these Laters, which we were able to define really quickly in a DSL-like style, now gain all the fancy features of `NSOperation`s for free. For example, these three operations will now fire in the order we specified (`assertOperation` is last):
+let queue = OperationQueue()
+queue.addOperations([lastOperation, firstOperation, secondOperation], waitUntilFinished: false)
+
+//
+// magical `MainQueue` zone
+//
+
+// finally, we can use some sneaky type tricks to add other useful information to certain Laters. A `MainQueueAnyLater` is a `Later` that is guaranteed to call its callback on the main thread:
+let x: MainQueueAnyLater<Int> = sendTrue
+    .map { $0 ? 9 : 999 }
+    // the magic is in these two operators here. Any `Later` chain which ends with `.dispatchMain` followed by `.eraseToAnyLater` is “erased” to a `MainQueueAnyLater` (as opposed to just an `AnyLater`). This means that we can write UI functions — for example — which insists that its data be provided by `MainQueueAnyLater`s, which means we are guaranteed that we will be on the right thread before hitting the UI
+    .dispatchMain()
+    .eraseToAnyLater()
+
+// ie. for a `MainQueueAnyLater`, this should always hold…
+x.run { _ in precondition(Thread.isMainThread) }
+
+// we can get the same level of safety for other queues as well. Imagine this is some special work queue we have:
+let anotherQueue = DispatchQueue.global()
+
+// we wrap it in a struct to “tag” it…
+struct MyQueue: TaggedQueue {
+    func getQueue() -> DispatchQueue {
+        anotherQueue
+    }
+}
+
+// and then do whatever we like with Laters API. The resulting type of any `Later` operations which end with a dispatch to that tagged queue, followed by `erase…`, yields a `TaggedQueueAnyLater` which the compiler knows is associated with `MyQueue`.
+let y: TaggedQueueAnyLater<Bool, MyQueue> = sendTrue
+    .dispatchAsync(taggedQueue: MyQueue())
+    .eraseToAnyLater()
+
+// you can then use this type signature to enforce, in the type system, that work is executing on the queues you require:
+y
+    .tap { _ in print("I’m on a global queue!") }
+    .run { _ in precondition(!Thread.isMainThread) }
 
 //
 //
 //
+
+// bonus: the rare double-erase will turn a `MainQueueAnyLater` back into a regular `AnyLater`!
+let z = Laters.After(deadline: .now(), queue: .global(), value: ())
+    .dispatchMain()
+    .eraseToAnyLater()
+    .eraseToAnyLater()

--- a/Sources/Prelude/Laters.swift
+++ b/Sources/Prelude/Laters.swift
@@ -104,18 +104,20 @@ public extension Later {
     }
 }
 
-extension Laters.DispatchAsync where T == Laters.MainQueue {
-    public func eraseToAnyLater() -> MainQueueAnyLater<L.Output> {
+extension Laters.DispatchAsync {
+    public func eraseToAnyLater() -> TaggedQueueAnyLater<Output, T> {
         .init(upstream: self.run)
     }
 }
 
 // MARK: - MainQueueAnyLater
 
-public struct MainQueueAnyLater<A> {
+public typealias MainQueueAnyLater<A> = TaggedQueueAnyLater<A, Laters.MainQueue>
+
+public struct TaggedQueueAnyLater<A, T: TaggedQueue> {
     fileprivate let upstream: (@escaping (A) -> Void) -> Void
 }
-extension MainQueueAnyLater: Later {
+extension TaggedQueueAnyLater: Later {
     public typealias Output = A
 
     public func run(_ next: @escaping (A) -> Void) {

--- a/Tests/PreludeTests/LatersTests.swift
+++ b/Tests/PreludeTests/LatersTests.swift
@@ -62,6 +62,39 @@ final class LatersTests: XCTestCase {
         XCTAssertTrue(testValue)
     }
 
+    func testLaterDispatchMain() {
+        var testValue = false
+
+        let expect = expectation(description: "later")
+        sendTrue()
+            .dispatchMain()
+            .tap { _ in XCTAssertTrue(Thread.isMainThread) }
+            .run { value in
+                testValue = value
+                expect.fulfill()
+        }
+        waitForExpectations(timeout: 2, handler: nil)
+
+        XCTAssertTrue(testValue)
+    }
+
+    // compiler tests?! The following manually annotated types should be correct:
+    private let t1: Laters.DispatchAsync<Laters.After<Bool>, Laters.MainQueue> = sendTrue()
+        .dispatchMain()
+
+    private let t2: TaggedQueueAnyLater<Bool, Laters.MainQueue> = sendTrue()
+        .dispatchMain()
+        .eraseToAnyLater()
+
+    private let t3: MainQueueAnyLater<Bool> = sendTrue()
+        .dispatchMain()
+        .eraseToAnyLater()
+
+    private let t4: AnyLater<Bool> = sendTrue()
+        .dispatchMain()
+        .eraseToAnyLater()
+        .eraseToAnyLater()
+
     func testLaterFlatMap() {
         var testValue = ""
 


### PR DESCRIPTION
## Tagged Queues:
* add another type parameter to `Laters.DispatchAsync` which represents the queue
* for the pre-existing API, this type is always fixed to `Laters.AnyQueue`, which represents whatever `DispatchQueue` was passed in, in an “opaque” (not visible to the type system) way.
* however, add the API: `Later.dispatchMain()`. This results in a `Laters.DispatchAsync` where the type parameter for the queue is a special one: `Laters.MainQueue`. Therefore when using this operator, the type system can know that the programmer used the main queue.
* therefore, we can provide a few more special overloads when we know we will be on `main`, in particular: `Later.eraseToAnyLater()` when on the main queue now results in a special “erased” type: `MainQueueAnyLater<T>`.
* `MainQueueAnyLater` is useful because it can be used, by name, to restrict UI code to only accepting Laters which the compiler knows have been pre-dispatched to the main queue already, thus eliminating the need for manual code review to ensure dispatching, or defensive dispatching when code review of upstream async code is impossible. For example:

```swift
func performUIUpdate(withData later: MainQueueAnyLater<MyModel>) {
  later.run { value in
    // guaranteed to be on the main queue here
  }
}
```

This implementation works, but may not be as ergonomic as it could be right now. For details, see the tests and the `Laters` playground.