### PR TITLE
Make @dynamicMemberLookup subscript method public

### DIFF
--- a/Sources/Prelude/ChangeTracking.swift
+++ b/Sources/Prelude/ChangeTracking.swift
@@ -17,7 +17,7 @@
         self.value = value
     }
 
-    subscript<T>(dynamicMember keyPath: KeyPath<A, T>) -> T {
+    public subscript<T>(dynamicMember keyPath: KeyPath<A, T>) -> T {
         value[keyPath: keyPath]
     }
 }


### PR DESCRIPTION
When compiling into an XCFramework, the `subscript(dynamicMember:)` method needs to be public now in Xcode 12 or the compiler complains that the @dynamicMemberLookup requirements are not being fulfilled.