### PR TITLE
Fix a version for App Store validation

### DIFF
--- a/Prelude.xcodeproj/Prelude_Info.plist
+++ b/Prelude.xcodeproj/Prelude_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1.0</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>


### PR DESCRIPTION
This value was evaluated to an empty string, so the final plist was not valid for App Store submission.